### PR TITLE
Update ParserCombinator.jl

### DIFF
--- a/src/ParserCombinator.jl
+++ b/src/ParserCombinator.jl
@@ -32,7 +32,7 @@ Word, Space, Star, Plus,
 TrySource, Try, parse_try, parse_try_dbg, parse_try_cache, parse_try_cache_dbg,
 Parsers
 
-FAST_REGEX = isdefined(Main, :FAST_REGEX) ? Main.FAST_REGEX : VERSION >= v"0.4.0"
+FAST_REGEX = isdefined(Main, :FAST_REGEX) ? Main.FAST_REGEX : VERSION >= v"0.4.0-dev+6325"
 
 include("core/types.jl")
 include("core/sources.jl")


### PR DESCRIPTION
Change FAST_REGEX to use the specific patchlevel for Julia in advance of 0.4.0 release.