### PR TITLE
Update ParserCombinator.jl

### DIFF
--- a/src/ParserCombinator.jl
+++ b/src/ParserCombinator.jl
@@ -4,6 +4,7 @@ module ParserCombinator
 using Compat
 using AutoHashEquals
 import Base: start, next, done, endof, getindex, colon, isless, size, hash
+import Base: ==, ~, +, &, |, >=, >, |>
 
 export Matcher, 
 diagnostic, forwards, LineSource, LineIter,


### PR DESCRIPTION
Fix warnings in latest -nightly:

```
WARNING: module ParserCombinator should explicitly import == from Base
WARNING: module ParserCombinator should explicitly import ~ from Base
WARNING: module ParserCombinator should explicitly import + from Base
WARNING: module ParserCombinator should explicitly import & from Base
WARNING: module ParserCombinator should explicitly import | from Base
WARNING: module ParserCombinator should explicitly import >= from Base
WARNING: module ParserCombinator should explicitly import > from Base
WARNING: module ParserCombinator should explicitly import |> from Base
```