### PR TITLE
Update AutoHashEquals compat to support versions 1 and 2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ParserCombinator"
 uuid = "fae87a5f-d1ad-5cf0-8f61-c941e1580b46"
-version = "2.1.2"
+version = "2.2.0"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "ParserCombinator"
 uuid = "fae87a5f-d1ad-5cf0-8f61-c941e1580b46"
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-AutoHashEquals = "0.2"
+AutoHashEquals = "0.2, 1, 2"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
The latest version of AutoHashEquals is 2.0.0, but packages that use both AutoHashEquals and ParserCombinator are prevented from upgrading due to ParserCombinator's compat requirements. This PR fixes that.